### PR TITLE
fix ioutil

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -48,7 +47,7 @@ func buildList() []kubeChoice {
 
 	kubieFolder := filepath.Join(dirname, ".kube/kubie")
 
-	files, err := ioutil.ReadDir(kubieFolder)
+	files, err := os.ReadDir(kubieFolder)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -59,7 +58,7 @@ func buildList() []kubeChoice {
 	}
 
 	for _, file := range files {
-		if file.Mode().IsRegular() {
+		if file.Type().IsRegular() {
 			ext := filepath.Ext(file.Name())
 			if ext == ".yaml" || ext == ".yml" {
 

--- a/cmd/kube.go
+++ b/cmd/kube.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,7 +24,7 @@ type kubeChoice struct {
 }
 
 func ProcessFromPipe() *kubeChoice {
-	bytes, _ := ioutil.ReadAll(os.Stdin)
+	bytes, _ := io.ReadAll(os.Stdin)
 
 	// test if there is something on STDIN
 	if len(bytes) > 0 {


### PR DESCRIPTION

**What this PR does / why we need it**:

"io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code


**Release note**:

```release-note
fix ioutil function
```